### PR TITLE
fix readme python version to avoid error

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Or  ```pip install -r requirements.txt``` , and then double click the `install.b
 ### Linux
 
 ```bash
-conda create -n GPTSoVits python=3.9
+conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
 bash install.sh
 ```
@@ -112,7 +112,7 @@ bash install.sh
 First make sure you have installed FFmpeg by running `brew install ffmpeg` or `conda install ffmpeg`, then install by using the following commands:
 
 ```bash
-conda create -n GPTSoVits python=3.9
+conda create -n GPTSoVits python=3.10
 conda activate GPTSoVits
 
 pip install -r requirements.txt


### PR DESCRIPTION
## summary
py 3.9 caused the error below due to the use of the | operator for type hinting in Python, which is not compatible with the version 3.9. The | operator for type union was introduced in Python 3.10
 
error:
```
GPT-SoVITS-Inference/webuis/builders/gradio_builder.py", line 28, in GradioTabBuilder
    def __init__(self, component_name_list: List[str|List[str]], params_config: Dict[str, ParamItem]):
TypeError: unsupported operand type(s) for |: 'type' and '_GenericAlias'
```

## test
`conda create -n GPTSoVits10 python=3.10`